### PR TITLE
Use Plug 0.14 with conn.request.path

### DIFF
--- a/lib/plug_redirect_https.ex
+++ b/lib/plug_redirect_https.ex
@@ -31,7 +31,7 @@ defmodule PlugRedirectHttps do
   """
   def call(conn, _opts) do
     conn
-    |> get_forwarded_protocol 
+    |> get_forwarded_protocol
     |> redirect_to_https?
     |> handle_request(conn)
   end
@@ -57,7 +57,7 @@ defmodule PlugRedirectHttps do
 
   defp redirect_to_https?("http"), do: true
   defp redirect_to_https?(_proto), do: false
-  
+
   defp redirect_to_https(conn) do
     conn
     |> Plug.Conn.put_resp_header("location", get_current_url_as_proxied_https(conn))
@@ -70,7 +70,7 @@ defmodule PlugRedirectHttps do
   end
 
   defp rewrite_url_as_https(conn = %Plug.Conn{query_string: query_string}) do
-    https_url_with_path(get_forwarded_host(conn), Plug.Conn.full_path(conn), query_string)
+    https_url_with_path(get_forwarded_host(conn), conn.request_path, query_string)
   end
 
   defp https_url_with_path(host, path, ""), do: "https://#{host}#{path}"

--- a/mix.exs
+++ b/mix.exs
@@ -23,7 +23,7 @@ defmodule PlugRedirectHttps.Mixfile do
     [ contributors: ["Bob Stockdale"],
     licenses: ["MIT License"],
     links: %{
-      "GitHub" => "https://github.com/stocks29/plug_redirect_https.git", 
+      "GitHub" => "https://github.com/stocks29/plug_redirect_https.git",
       "Docs" => "http://hexdocs.pm/plug_redirect_https"
       }]
   end
@@ -46,7 +46,7 @@ defmodule PlugRedirectHttps.Mixfile do
   # Type `mix help deps` for more examples and options
   defp deps do
     [
-      {:plug, "~> 0.12.2"},
+      {:plug, "~> 0.14"},
       {:earmark, "~> 0.1", only: :dev},
       {:ex_doc, "~> 0.7", only: :dev}
     ]

--- a/mix.exs
+++ b/mix.exs
@@ -46,7 +46,7 @@ defmodule PlugRedirectHttps.Mixfile do
   # Type `mix help deps` for more examples and options
   defp deps do
     [
-      {:plug, "~> 0.14"},
+      {:plug, "~> 1.0"},
       {:earmark, "~> 0.1", only: :dev},
       {:ex_doc, "~> 0.7", only: :dev}
     ]

--- a/mix.lock
+++ b/mix.lock
@@ -1,3 +1,3 @@
 %{"earmark": {:hex, :earmark, "0.1.13"},
   "ex_doc": {:hex, :ex_doc, "0.7.2"},
-  "plug": {:hex, :plug, "0.14.0"}}
+  "plug": {:hex, :plug, "1.0.0"}}

--- a/mix.lock
+++ b/mix.lock
@@ -1,3 +1,3 @@
 %{"earmark": {:hex, :earmark, "0.1.13"},
   "ex_doc": {:hex, :ex_doc, "0.7.2"},
-  "plug": {:hex, :plug, "0.12.2"}}
+  "plug": {:hex, :plug, "0.14.0"}}


### PR DESCRIPTION
This upgrades the removed Plug.Conn.full_path(conn) to the replacement conn.request_path
