### PR TITLE
Do not lock Plug to version 1.1.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 sudo: false
 language: elixir
-elixir: 1.0.5
+elixir: 1.3.4
 otp_release:
-  - 18.0
+  - 19.1
 env: MIX_ENV=test

--- a/README.md
+++ b/README.md
@@ -10,5 +10,5 @@ API documentation is available at http://hexdocs.pm/plug_redirect_https
 ### Add as dependency
 
 ```elixir
-  {:plug_redirect_https, "~> 0.0.6"}
+  {:plug_redirect_https, "~> 0.0.7"}
 ```

--- a/mix.exs
+++ b/mix.exs
@@ -2,15 +2,17 @@ defmodule PlugRedirectHttps.Mixfile do
   use Mix.Project
 
   def project do
-    [app: :plug_redirect_https,
-     version: "0.0.6",
-     elixir: "~> 1.0",
-     name: "plug_redirect_https",
-     source_url: "https://github.com/stocks29/plug_redirect_https",
-     homepage_url: "https://github.com/stocks29/plug_redirect_https",
-     description: description,
-     package: package,
-     deps: deps]
+    [
+      app: :plug_redirect_https,
+      version: "0.0.7",
+      elixir: "~> 1.0",
+      name: "plug_redirect_https",
+      source_url: "https://github.com/stocks29/plug_redirect_https",
+      homepage_url: "https://github.com/stocks29/plug_redirect_https",
+      description: description,
+      package: package,
+      deps: deps
+    ]
   end
 
   def description do
@@ -20,33 +22,23 @@ defmodule PlugRedirectHttps.Mixfile do
   end
 
   def package do
-    [ maintainers: ["Bob Stockdale"],
-    licenses: ["MIT License"],
-    links: %{
-      "GitHub" => "https://github.com/stocks29/plug_redirect_https.git",
-      "Docs" => "http://hexdocs.pm/plug_redirect_https"
-      }]
+    [
+      maintainers: ["Bob Stockdale"],
+      licenses: ["MIT License"],
+      links: %{
+        "GitHub" => "https://github.com/stocks29/plug_redirect_https.git",
+        "Docs" => "http://hexdocs.pm/plug_redirect_https"
+      }
+    ]
   end
 
-  # Configuration for the OTP application
-  #
-  # Type `mix help compile.app` for more information
   def application do
     [applications: [:logger]]
   end
 
-  # Dependencies can be Hex packages:
-  #
-  #   {:mydep, "~> 0.3.0"}
-  #
-  # Or git/path repositories:
-  #
-  #   {:mydep, git: "https://github.com/elixir-lang/mydep.git", tag: "0.1.0"}
-  #
-  # Type `mix help deps` for more examples and options
   defp deps do
     [
-      {:plug, "~> 1.1.1"},
+      {:plug, "~> 1.1"},
       {:earmark, "~> 0.2.1", only: :dev},
       {:ex_doc, "~> 0.11.4", only: :dev}
     ]

--- a/mix.lock
+++ b/mix.lock
@@ -1,3 +1,4 @@
-%{"earmark": {:hex, :earmark, "0.2.1"},
-  "ex_doc": {:hex, :ex_doc, "0.11.4"},
-  "plug": {:hex, :plug, "1.1.2"}}
+%{"earmark": {:hex, :earmark, "0.2.1", "ba6d26ceb16106d069b289df66751734802777a3cbb6787026dd800ffeb850f3", [:mix], []},
+  "ex_doc": {:hex, :ex_doc, "0.11.5", "0dc51cb84f8312162a2313d6c71573a9afa332333d8a332bb12540861b9834db", [:mix], [{:earmark, "~> 0.1.17 or ~> 0.2", [hex: :earmark, optional: true]}]},
+  "mime": {:hex, :mime, "1.0.1", "05c393850524767d13a53627df71beeebb016205eb43bfbd92d14d24ec7a1b51", [:mix], []},
+  "plug": {:hex, :plug, "1.3.0", "6e2b01afc5db3fd011ca4a16efd9cb424528c157c30a44a0186bcc92c7b2e8f3", [:mix], [{:cowboy, "~> 1.0.1 or ~> 1.1", [hex: :cowboy, optional: true]}, {:mime, "~> 1.0", [hex: :mime, optional: false]}]}}


### PR DESCRIPTION
Locking the version of Plug to 1.1.x is a bit too restrictive. Later versions of Plug fixes a number of deprecation warnings.